### PR TITLE
fix(data.py): add symbolic link support

### DIFF
--- a/lib/data/data.py
+++ b/lib/data/data.py
@@ -18,8 +18,8 @@ from lib.fun.osjudger import py_ver_egt_3
 
 def init_paths():
     try:
-        root_path = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0]))).encode('utf-8').decode() \
-            if py_ver_egt_3 else os.path.dirname(os.path.abspath(sys.argv[0])).decode('utf-8')
+        root_path = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0]))).encode('utf-8').decode() \
+            if py_ver_egt_3 else os.path.dirname(os.path.realpath(sys.argv[0])).decode('utf-8')
     except:
         root_path = 'fake path'
         exit("\n[-] Please ensure pydictor directory path name is english characters\n")


### PR DESCRIPTION
In current version, pydictor won't work with symbolic links.

```bash
➜  ln -s /opt/pydictor/pydictor.py /usr/bin/pydictor
➜  pydictor 
Traceback (most recent call last):
  File "/usr/bin/pydictor", line 14, in <module>
    from core.BASE import get_base_dic
  File "/opt/pydictor/core/BASE.py", line 13, in <module>
    from lib.data.data import pystrs,  pyoptions
  File "/opt/pydictor/lib/data/data.py", line 307, in <module>
    init_pyoptions()
  File "/opt/pydictor/lib/data/data.py", line 212, in init_pyoptions
    pyoptions.core_range = [core[:-3].lower() for core in os.listdir(paths.core_path)
FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/pydictor'
```

With `os.path.realpath` instead of `os.path.abspath`, it will work either way.